### PR TITLE
Handle parameter override between path and operation level

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -27,7 +27,7 @@ impl std::fmt::Display for HttpMethod {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ParameterLocation {
     Path,
     Query,

--- a/tests/fixtures/parameter-override.yaml
+++ b/tests/fixtures/parameter-override.yaml
@@ -1,0 +1,54 @@
+openapi: "3.0.0"
+info:
+  title: Parameter Override Test API
+  version: "1.0.0"
+
+paths:
+  /items/{itemId}:
+    # Path-level parameter - should be used by default
+    parameters:
+      - name: itemId
+        in: path
+        required: true
+        description: Path level item ID
+        schema:
+          type: string
+      - name: version
+        in: query
+        required: false
+        description: API version from path level
+        schema:
+          type: string
+
+    get:
+      summary: Get item (uses path-level params)
+      responses:
+        "200":
+          description: OK
+
+    put:
+      summary: Update item (overrides itemId param)
+      # Operation-level parameter overrides path-level
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          description: Operation level item ID (overridden)
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+
+    delete:
+      summary: Delete item (overrides version param)
+      parameters:
+        - name: version
+          in: query
+          required: true
+          description: Required version for delete
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: Deleted


### PR DESCRIPTION
## Summary
- Use `HashMap<(name, location), Parameter>` to deduplicate parameters
- Operation-level parameters now correctly override path-level parameters (per OpenAPI spec)
- Add `Hash` derive to `ParameterLocation` for HashMap key usage

## Code improvements (via code-simplifier)
- Simplify `convert_parameter` with single match expression
- Optimize `type_to_string` to return `&'static str` instead of `String`

## Test plan
- [x] All 40 tests pass (`cargo test`)
- [x] Added test fixture `tests/fixtures/parameter-override.yaml`
- [x] Added 3 new tests for parameter override scenarios

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/claude-code)